### PR TITLE
Redirect post request

### DIFF
--- a/server.go
+++ b/server.go
@@ -31,7 +31,7 @@ func handler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	for _, record := range txt {
-		redirect := Translate(r.URL.String(), Parse(record))
+		redirect := Translate(r.Method, r.URL.String(), Parse(record))
 		if redirect != nil {
 			http.Redirect(w, r, redirect.Location, redirect.Status)
 			return

--- a/translate.go
+++ b/translate.go
@@ -11,7 +11,7 @@ type Redirect struct {
 	Status   int
 }
 
-func Translate(uri string, config *Config) *Redirect {
+func Translate(method string, uri string, config *Config) *Redirect {
 	if uri == "" {
 		return nil
 	}
@@ -24,13 +24,18 @@ func Translate(uri string, config *Config) *Redirect {
 
 	redirect := &Redirect{Location: config.To}
 
-	switch config.RedirectState {
-	case "301", "permanently":
-		redirect.Status = 301
-	case "302", "temporarily":
-		redirect.Status = 302
+	switch method {
+	case "POST":
+		redirect.Status = 307
 	default:
-		redirect.Status = 302
+		switch config.RedirectState {
+		case "301", "permanently":
+			redirect.Status = 301
+		case "302", "temporarily":
+			redirect.Status = 302
+		default:
+			redirect.Status = 302
+		}
 	}
 
 	// no `From` assumes catch-all, so redirect immediately to `Location`

--- a/translate_test.go
+++ b/translate_test.go
@@ -5,25 +5,25 @@ import "testing"
 func TestTranslate(t *testing.T) {
 	var redirect *Redirect
 
-	redirect = Translate("/", nil)
+	redirect = Translate("GET", "/", nil)
 	if redirect != nil {
 		t.Errorf("Expected %#v to be %#v", redirect, nil)
 	}
 
-	redirect = Translate("/", &Config{To: "https://example.com/"})
+	redirect = Translate("GET", "/", &Config{To: "https://example.com/"})
 	assertEqual(t, redirect.Location, "https://example.com/")
 	assertEqual(t, redirect.Status, 302)
 
-	redirect = Translate("/", &Config{To: "https://example.com/", RedirectState: "301"})
+	redirect = Translate("GET", "/", &Config{To: "https://example.com/", RedirectState: "301"})
 	assertEqual(t, redirect.Location, "https://example.com/")
 	assertEqual(t, redirect.Status, 301)
 
-	redirect = Translate("/", &Config{From: "/twitter", To: "https://example.com/", RedirectState: "permanently"})
+	redirect = Translate("GET", "/", &Config{From: "/twitter", To: "https://example.com/", RedirectState: "permanently"})
 	if redirect != nil {
 		t.Errorf("Expected %#v to be %#v", redirect, nil)
 	}
 
-	redirect = Translate("/", &Config{From: "/", To: "https://example.com/", RedirectState: "permanently"})
+	redirect = Translate("GET", "/", &Config{From: "/", To: "https://example.com/", RedirectState: "permanently"})
 	assertEqual(t, redirect.Location, "https://example.com/")
 	assertEqual(t, redirect.Status, 301)
 }
@@ -31,32 +31,45 @@ func TestTranslate(t *testing.T) {
 func TestTranslateWildcard(t *testing.T) {
 	var redirect *Redirect
 
-	redirect = Translate("/about-us", &Config{From: "/*", To: "http://example.com/"})
+	redirect = Translate("GET", "/about-us", &Config{From: "/*", To: "http://example.com/"})
 	assertEqual(t, redirect.Location, "http://example.com/")
 	assertEqual(t, redirect.Status, 302)
 
-	redirect = Translate("/about-us", &Config{From: "/*", To: "http://example.com/*"})
+	redirect = Translate("GET", "/about-us", &Config{From: "/*", To: "http://example.com/*"})
 	assertEqual(t, redirect.Location, "http://example.com/about-us")
 	assertEqual(t, redirect.Status, 302)
 
-	redirect = Translate("/about-us", &Config{From: "/*", To: "http://example.com/*"})
+	redirect = Translate("GET", "/about-us", &Config{From: "/*", To: "http://example.com/*"})
 	assertEqual(t, redirect.Location, "http://example.com/about-us")
 	assertEqual(t, redirect.Status, 302)
 
-	redirect = Translate("/blog/1", &Config{From: "/*/1", To: "http://example.com/*", RedirectState: "temporarily"})
+	redirect = Translate("GET", "/blog/1", &Config{From: "/*/1", To: "http://example.com/*", RedirectState: "temporarily"})
 	assertEqual(t, redirect.Location, "http://example.com/blog")
 	assertEqual(t, redirect.Status, 302)
 
-	redirect = Translate("/wildcard", &Config{From: "/*", To: "http://example.com/**"})
+	redirect = Translate("GET", "/wildcard", &Config{From: "/*", To: "http://example.com/**"})
 	assertEqual(t, redirect.Location, "http://example.com/wildcard*")
 	assertEqual(t, redirect.Status, 302)
 
-	redirect = Translate("/wildcard", &Config{From: "/**", To: "http://example.com/*"})
+	redirect = Translate("GET", "/wildcard", &Config{From: "/**", To: "http://example.com/*"})
 	if redirect != nil {
 		t.Errorf("Expected %#v to be %#v", redirect, nil)
 	}
 
-	redirect = Translate("/wildcard*", &Config{From: "/**", To: "http://example.com/*"})
+	redirect = Translate("GET", "/wildcard*", &Config{From: "/**", To: "http://example.com/*"})
 	assertEqual(t, redirect.Location, "http://example.com/wildcard")
 	assertEqual(t, redirect.Status, 302)
+}
+
+func TestTranslateStatus(t *testing.T)  {
+	var redirect *Redirect
+
+	redirect = Translate("POST", "/", &Config{From: "/*", To: "http://example.com/*"})
+	assertEqual(t, redirect.Status, 307)
+
+	redirect = Translate("POST", "/", &Config{From: "/*", To: "http://example.com/*", RedirectState: "permanently"})
+	assertEqual(t, redirect.Status, 307)
+
+	redirect = Translate("POST", "/", &Config{From: "/*", To: "http://example.com/*", RedirectState: "temporarily"})
+	assertEqual(t, redirect.Status, 307)
 }


### PR DESCRIPTION
This addresses issue #12 

If the http method is `POST`, redirect with a status of 307, regardless of the `config.RedirectState`; otherwise, business as usual. My "integration test" for this was along the lines of what I mentioned in #10; I have a "thing-service" hosted for free on heroku, with a redirect set up for a subdomain of my site. Running this branch locally, and curl-ing it with that subdomain as the Host header, I verified that both the request and body were successfully redirected.