### PR TITLE
Process redirects in two stages to ensure catch alls don't override more specific matches

### DIFF
--- a/server.go
+++ b/server.go
@@ -43,18 +43,18 @@ func handler(w http.ResponseWriter, r *http.Request) {
 
 	logDebug("Checking URL: %s", r.URL.String())
 
-	var catch_alls []string
+	catch_alls := make(map[string]*Config)
+
 	logDebug("Begin record search.")
 	for _, record := range txt {
 		logDebug("Inspecting: %s", record)
 		config := Parse(record)
 		if strings.TrimSpace(config.From) == "" {
 			logDebug("Saving catch all.")
-			catch_alls = append(catch_alls, record)
-			_ = catch_alls
+			catch_alls[record] = config
 			continue
 		}
-		redirect := Translate(r.URL.String(), Parse(record))
+		redirect := Translate(r.URL.String(), config)
 		if redirect != nil {
 			http.Redirect(w, r, redirect.Location, redirect.Status)
 			logDebug("Found matching record.")
@@ -64,9 +64,11 @@ func handler(w http.ResponseWriter, r *http.Request) {
 	logDebug("End record search")
 
 	logDebug("Begin catch alls")
-	for _, record := range catch_alls {
+	var record string
+	var config *Config
+	for record, config = range catch_alls {
 		logDebug("Inspecting: %s", record)
-		redirect := Translate(r.URL.String(), Parse(record))
+		redirect := Translate(r.URL.String(), config)
 		if redirect != nil {
 			http.Redirect(w, r, redirect.Location, redirect.Status)
 			logDebug("Found catch all.")

--- a/server.go
+++ b/server.go
@@ -11,17 +11,6 @@ import (
 	"time"
 )
 
-var debug = os.Getenv("DEBUG")
-func logDebug(format string, args ...interface{}) {
-	if debug != "" {
-		if len(args) == 0 {
-			log.Print(format)
-		} else {
-			log.Printf(format, args)
-		}
-	}
-}
-
 func fallback(w http.ResponseWriter, r *http.Request, reason string) {
 	location := "http://redirect.name/"
 	if reason != "" {
@@ -41,41 +30,29 @@ func handler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	logDebug("Checking URL: %s", r.URL.String())
-
 	catch_alls := make(map[string]*Config)
 
-	logDebug("Begin record search.")
 	for _, record := range txt {
-		logDebug("Inspecting: %s", record)
 		config := Parse(record)
 		if strings.TrimSpace(config.From) == "" {
-			logDebug("Saving catch all.")
 			catch_alls[record] = config
 			continue
 		}
 		redirect := Translate(r.URL.String(), config)
 		if redirect != nil {
 			http.Redirect(w, r, redirect.Location, redirect.Status)
-			logDebug("Found matching record.")
 			return
 		}
 	}
-	logDebug("End record search")
 
-	logDebug("Begin catch alls")
-	var record string
 	var config *Config
-	for record, config = range catch_alls {
-		logDebug("Inspecting: %s", record)
+	for _, config = range catch_alls {
 		redirect := Translate(r.URL.String(), config)
 		if redirect != nil {
 			http.Redirect(w, r, redirect.Location, redirect.Status)
-			logDebug("Found catch all.")
 			return
 		}
 	}
-	logDebug("No match found.")
 
 	fallback(w, r, "No paths matched")
 }

--- a/server.go
+++ b/server.go
@@ -11,6 +11,17 @@ import (
 	"time"
 )
 
+var debug = os.Getenv("DEBUG")
+func logDebug(format string, args ...interface{}) {
+	if debug != "" {
+		if len(args) == 0 {
+			log.Print(format)
+		} else {
+			log.Printf(format, args)
+		}
+	}
+}
+
 func fallback(w http.ResponseWriter, r *http.Request, reason string) {
 	location := "http://redirect.name/"
 	if reason != "" {
@@ -30,13 +41,39 @@ func handler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	logDebug("Checking URL: %s", r.URL.String())
+
+	var catch_alls []string
+	logDebug("Begin record search.")
 	for _, record := range txt {
+		logDebug("Inspecting: %s", record)
+		config := Parse(record)
+		if strings.TrimSpace(config.From) == "" {
+			logDebug("Saving catch all.")
+			catch_alls = append(catch_alls, record)
+			_ = catch_alls
+			continue
+		}
 		redirect := Translate(r.URL.String(), Parse(record))
 		if redirect != nil {
 			http.Redirect(w, r, redirect.Location, redirect.Status)
+			logDebug("Found matching record.")
 			return
 		}
 	}
+	logDebug("End record search")
+
+	logDebug("Begin catch alls")
+	for _, record := range catch_alls {
+		logDebug("Inspecting: %s", record)
+		redirect := Translate(r.URL.String(), Parse(record))
+		if redirect != nil {
+			http.Redirect(w, r, redirect.Location, redirect.Status)
+			logDebug("Found catch all.")
+			return
+		}
+	}
+	logDebug("No match found.")
 
 	fallback(w, r, "No paths matched")
 }

--- a/server.go
+++ b/server.go
@@ -21,12 +21,11 @@ func fallback(w http.ResponseWriter, r *http.Request, reason string) {
 }
 
 func getRedirect(txt []string, url string) (*Redirect, error) {
-	catch_alls := make(map[string]*Config)
-
+	var catchAlls []*Config
 	for _, record := range txt {
 		config := Parse(record)
-		if strings.TrimSpace(config.From) == "" {
-			catch_alls[record] = config
+		if config.From == "" {
+			catchAlls = append(catchAlls, config)
 			continue
 		}
 		redirect := Translate(url, config)
@@ -36,7 +35,7 @@ func getRedirect(txt []string, url string) (*Redirect, error) {
 	}
 
 	var config *Config
-	for _, config = range catch_alls {
+	for _, config = range catchAlls {
 		redirect := Translate(url, config)
 		if redirect != nil {
 			return redirect, nil

--- a/server_test.go
+++ b/server_test.go
@@ -1,0 +1,52 @@
+package main
+
+import "testing"
+
+func TestGetRedirectSimple(t *testing.T) {
+	var redirect *Redirect
+	var err error
+
+	dnsTXT := []string{
+		"Redirects from /test/* to https://github.com/holic/*",
+	}
+
+	redirect, err = getRedirect(dnsTXT, "/test/")
+	assertEqual(t, err, nil)
+	assertEqual(t, redirect.Location, "https://github.com/holic/")
+
+	redirect, err = getRedirect(dnsTXT, "/test/success")
+	assertEqual(t, err, nil)
+	assertEqual(t, redirect.Location, "https://github.com/holic/success")
+
+	redirect, err = getRedirect(dnsTXT, "/should/fail")
+	assertEqual(t, err.Error(), "No paths matched")
+}
+
+func TestGetRedirectComplex(t *testing.T) {
+	// Tests that catchalls (even interspersed in the TXT records) apply
+	// only after more specific matches
+	var redirect *Redirect
+	var err error
+
+	dnsTXT := []string{
+		"Redirects from /test/* to https://github.com/holic/*",
+		"Redirects to https://github.com/holic",
+		"Redirects from /noglob/ to https://github.com/holic/noglob",
+	}
+
+	redirect, err = getRedirect(dnsTXT, "/")
+	assertEqual(t, err, nil)
+	assertEqual(t, redirect.Location, "https://github.com/holic")
+
+	redirect, err = getRedirect(dnsTXT, "/test/somepath")
+	assertEqual(t, err, nil)
+	assertEqual(t, redirect.Location, "https://github.com/holic/somepath")
+
+	redirect, err = getRedirect(dnsTXT, "/noglob/")
+	assertEqual(t, err, nil)
+	assertEqual(t, redirect.Location, "https://github.com/holic/noglob")
+
+	redirect, err = getRedirect(dnsTXT, "/catch/all")
+	assertEqual(t, err, nil)
+	assertEqual(t, redirect.Location, "https://github.com/holic")
+}


### PR DESCRIPTION
I found that depending on the order in which the TXT records are processed that a catch all record can unintentionally match before a more specific record resulting in incorrect redirects.

I tested with the following records:
```
_redirect.test.elementalvoid.com. 300 IN TXT    "Redirects to http://shell-abuse.ninja/"
_redirect.test.elementalvoid.com. 300 IN TXT    "Redirects permanently from /perm to https://github.com/elementalvoid/"
_redirect.test.elementalvoid.com. 300 IN TXT    "Redirects from /test/* to https://elementalvoid.com/*"
_redirect.test.elementalvoid.com. 300 IN TXT    "Redirects from /hub/ to https://github.com/elementalvoid/"
_redirect.test.elementalvoid.com. 300 IN TXT    "Redirects from /github to https://github.com/elementalvoid/"
```

Before this fix a request for `http://test.elementalvoid.com/catchall-test` would always work. However, a request for `http://test.elementalvoid.com/test/foo` would sometimes work as desired and sometimes it would get redirected by the catch all. The problem was that the catch all record was process _before_ the more specific record. Additionally, it would work properly every fifth request due to the round robin fashion of things.

This fix processes the records in two phases; first the specific redirects and second all catch alls.