### PR TITLE
Making URIs more flexible

### DIFF
--- a/parse.go
+++ b/parse.go
@@ -10,7 +10,7 @@ type Config struct {
 
 var configRE = regexp.MustCompile(`Redirects?(\s+.*)`)
 var fromRE = regexp.MustCompile(`\s+from\s+(/\S*)`)
-var toRE = regexp.MustCompile(`\s+to\s+(https?\://\S+|/\S*)`)
+var toRE = regexp.MustCompile(`\s+to\s+(\S+\:\S+|/\S*)`)
 var stateRE = regexp.MustCompile(`\s+(permanently|temporarily)|\s+with\s+(301|302|307|308)`)
 
 func Parse(record string) *Config {

--- a/parse.go
+++ b/parse.go
@@ -10,7 +10,7 @@ type Config struct {
 
 var configRE = regexp.MustCompile(`Redirects?(\s+.*)`)
 var fromRE = regexp.MustCompile(`\s+from\s+(/\S*)`)
-var toRE = regexp.MustCompile(`\s+to\s+(\S+\:\S+|/\S*)`)
+var toRE = regexp.MustCompile(`\s+to\s+((?:http\://|https\://|ftp\://|mailto\:|magnet\:)\S+|/\S*)`)
 var stateRE = regexp.MustCompile(`\s+(permanently|temporarily)|\s+with\s+(301|302|307|308)`)
 
 func Parse(record string) *Config {

--- a/parse_test.go
+++ b/parse_test.go
@@ -21,6 +21,16 @@ func TestParse(t *testing.T) {
 	assertEqual(t, config.To, "http://github.com/holic")
 	assertEqual(t, config.RedirectState, "")
 
+	config = Parse("Redirect to ftp://github.com")
+	assertEqual(t, config.From, "")
+	assertEqual(t, config.To, "ftp://github.com")
+	assertEqual(t, config.RedirectState, "")
+
+	config = Parse("Redirect to mailto:test@example.com")
+	assertEqual(t, config.From, "")
+	assertEqual(t, config.To, "mailto:test@example.com")
+	assertEqual(t, config.RedirectState, "")
+
 	config = Parse("Redirect from / to http://github.com/holic")
 	assertEqual(t, config.From, "/")
 	assertEqual(t, config.To, "http://github.com/holic")


### PR DESCRIPTION
According to RFC7231 the Location header may have any URI-reference
which seems to be defined by RFC3986 as a relative ref or full URI.
The URI seems to be more or less scheme : something (well it's more
involved but this might be good enough)