### PR TITLE
Polish docs page: fix inaccuracies and add a debugging section

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -133,6 +133,12 @@
       margin: 2.5rem 0;
     }
 
+    .note {
+      margin-top: 0.5rem;
+      font-size: 0.9rem;
+      color: #555;
+    }
+
     .step-num {
       display: inline-block;
       background: var(--accent);
@@ -159,8 +165,10 @@
 
   <h2>How it works</h2>
   <p>
-    Point a hostname at <code>alias.redirect.name</code> (or the IP), then add a TXT record
-    at <code>_redirect.&lt;hostname&gt;</code> with your redirect rule. That's it. The service reads your DNS and redirects visitors.
+    Two DNS records describe a redirect: one points your hostname at our server,
+    and a TXT record describes where to send visitors. We read the TXT record at
+    request time and issue the redirect. No accounts, no dashboard — your DNS
+    provider is the source of truth.
   </p>
 
   <hr>
@@ -168,28 +176,28 @@
   <h2>Setup</h2>
   <ol>
     <li>
-      Add a DNS record pointing your hostname to <code>redirect.name</code>:
-      <pre><code># Preferred: CNAME or ALIAS record
-CNAME  yoursubdomain.example.com  alias.redirect.name
-
-# Fallback: A record (use if your DNS provider doesn't support CNAME at apex)
-A      yoursubdomain.example.com  45.55.126.223</code></pre>
-    </li>
-    <li>
-      Add a TXT record with your redirect rule, using the <code>_redirect</code> prefix:
-      <pre><code>TXT  _redirect.yoursubdomain.example.com  "Redirects to https://example.com/"</code></pre>
-      <p style="margin-top: 0.5rem; font-size: 0.9rem; color: #555;">
-        The <code>_redirect</code> prefix is required because a CNAME record prevents other
-        record types (like TXT) from coexisting at the same name.
+      Point your hostname at <code>alias.redirect.name</code>:
+      <pre><code>CNAME  go.example.com.  alias.redirect.name.</code></pre>
+      <p class="note">
+        If your DNS provider doesn't allow CNAMEs (often the case at the apex of
+        a domain), use an A record to <code>45.55.126.223</code> instead.
       </p>
     </li>
-    <li>Wait for DNS to propagate (usually a few minutes), then visit your hostname.</li>
+    <li>
+      Add a TXT record at <code>_redirect.&lt;your-hostname&gt;</code>:
+      <pre><code>TXT  _redirect.go.example.com.  "Redirects to https://example.com/"</code></pre>
+      <p class="note">
+        The <code>_redirect.</code> prefix is required because TXT and CNAME
+        records can't coexist at the same name.
+      </p>
+    </li>
+    <li>Wait for DNS to propagate (usually a minute or two), then visit your hostname.</li>
   </ol>
 
   <hr>
 
   <h2>Redirect rules</h2>
-  <p>The TXT record value is your redirect rule. All matching is case-insensitive.</p>
+  <p>The TXT record value is the rule. The syntax is plain English:</p>
 
   <table>
     <thead>
@@ -201,60 +209,85 @@ A      yoursubdomain.example.com  45.55.126.223</code></pre>
     <tbody>
       <tr>
         <td><code>Redirects to &lt;url&gt;</code></td>
-        <td>302 redirect to URL</td>
+        <td>302 to <code>&lt;url&gt;</code></td>
       </tr>
       <tr>
         <td><code>Redirects permanently to &lt;url&gt;</code></td>
-        <td>301 redirect to URL</td>
-      </tr>
-      <tr>
-        <td><code>Redirects temporarily to &lt;url&gt;</code></td>
-        <td>302 redirect to URL (explicit)</td>
+        <td>301 to <code>&lt;url&gt;</code></td>
       </tr>
       <tr>
         <td><code>Redirects from &lt;path&gt; to &lt;url&gt;</code></td>
-        <td>302 redirect when path matches</td>
+        <td>302 when the request path matches</td>
       </tr>
       <tr>
-        <td><code>Redirects from &lt;path&gt; to &lt;url&gt; with 301</code></td>
-        <td>Redirect with specified status code (301, 302, 307, or 308)</td>
+        <td><code>Redirects from &lt;path&gt; to &lt;url&gt; with 308</code></td>
+        <td>Same, with explicit status — <code>301</code>, <code>302</code>, <code>307</code>, or <code>308</code></td>
       </tr>
       <tr>
         <td><code>Redirects from /path/* to https://example.com/*</code></td>
-        <td>Wildcard: <code>*</code> in destination is replaced with the matched portion</td>
+        <td>Wildcard — <code>*</code> in the destination receives the matched suffix</td>
       </tr>
     </tbody>
   </table>
 
   <p>
-    You can add multiple TXT records to the same hostname. Specific path matches take
-    priority over catch-all rules. Rules are evaluated in order; the first match wins.
+    Destinations can use <code>http://</code>, <code>https://</code>,
+    <code>ftp://</code>, <code>mailto:</code>, <code>magnet:</code>, or a
+    relative path.
+  </p>
+
+  <p>
+    You can add multiple TXT records at the same name. Path-specific rules
+    (<code>Redirects from …</code>) are checked first; catch-all rules
+    (<code>Redirects to …</code>) only apply if no path rule matches. DNS
+    doesn't guarantee an order between records at the same name, so within
+    each group the rules should be non-overlapping — if more than one could
+    match the same request, which wins is unspecified.
   </p>
 
   <hr>
 
   <h2>Examples</h2>
 
-  <p><strong>Simple redirect</strong> — send all traffic to a new URL:</p>
-  <pre><code>TXT  _redirect.go.example.com  "Redirects to https://www.example.com/"</code></pre>
+  <p><strong>Simple redirect</strong> — send all traffic to a single URL:</p>
+  <pre><code>TXT  _redirect.go.example.com.  "Redirects to https://www.example.com/"</code></pre>
 
-  <p><strong>Permanent redirect</strong> — tell browsers and search engines this is final:</p>
-  <pre><code>TXT  _redirect.old.example.com  "Redirects permanently to https://new.example.com/"</code></pre>
+  <p><strong>Permanent redirect</strong> — for moves that won't be undone:</p>
+  <pre><code>TXT  _redirect.old.example.com.  "Redirects permanently to https://new.example.com/"</code></pre>
 
-  <p><strong>Path-based routing</strong> — redirect a specific path, let others fall through:</p>
-  <pre><code>TXT  _redirect.docs.example.com  "Redirects from /api to https://api-docs.example.com/"
-TXT  _redirect.docs.example.com  "Redirects to https://docs.example.com/"</code></pre>
+  <p><strong>Path routing</strong> — redirect one path, send the rest somewhere else:</p>
+  <pre><code>TXT  _redirect.docs.example.com.  "Redirects from /api to https://api-docs.example.com/"
+TXT  _redirect.docs.example.com.  "Redirects to https://docs.example.com/"</code></pre>
 
-  <p><strong>Wildcard forwarding</strong> — preserve the path suffix:</p>
-  <pre><code>TXT  _redirect.links.example.com  "Redirects from /blog/* to https://blog.example.com/posts/*"</code></pre>
+  <p><strong>Wildcard forwarding</strong> — preserve the matched suffix in the destination:</p>
+  <pre><code>TXT  _redirect.links.example.com.  "Redirects from /blog/* to https://blog.example.com/posts/*"</code></pre>
+
+  <p><strong>Other schemes</strong> — redirect to mail, magnet links, etc.:</p>
+  <pre><code>TXT  _redirect.hi.example.com.  "Redirects to mailto:hello@example.com"</code></pre>
 
   <hr>
 
   <h2>HTTPS</h2>
   <p>
-    TLS certificates are provisioned automatically via Let's Encrypt on the first
-    request to a new hostname. The very first HTTPS request may be slow (a few seconds)
-    while the certificate is issued. Subsequent requests are fast.
+    HTTPS works out of the box. Certificates are issued automatically by
+    Let's Encrypt on the first request to a new hostname — that request may
+    take a couple of seconds while the cert is provisioned; everything after
+    is immediate.
+  </p>
+
+  <hr>
+
+  <h2>Verifying your setup</h2>
+  <p>If something isn't working, check what DNS is actually serving:</p>
+  <pre><code># Confirm the CNAME or A record resolves
+$ dig +short go.example.com.
+
+# Confirm the TXT record is reachable and matches what you set
+$ dig +short TXT _redirect.go.example.com.</code></pre>
+  <p>
+    If both look right but the redirect doesn't happen, the rule may not be
+    parsing. Make sure the value starts with the word <code>Redirects</code>
+    (capitalised) and that the destination is a fully qualified URL.
   </p>
 
   <hr>


### PR DESCRIPTION
## Summary

A polish pass on `docs/index.html` (the redirect.name homepage).

**Factual fixes**
- Setup step 1 was telling people to point their hostname at `redirect.name` while the code sample used `alias.redirect.name`. Now consistent on `alias.redirect.name`.
- Dropped the "All matching is case-insensitive" claim — the regexes in `parse.go` are case-sensitive, and so is path matching.
- Rewrote the rule-priority paragraph. The old text said "Rules are evaluated in order; the first match wins," which is misleading: `server.go` does prioritise path-specific rules over catch-alls (deterministic), but DNS doesn't guarantee record order within a name, so within either group there's no reliable "first." The new wording recommends keeping rules non-overlapping.

**Polish**
- Split the CNAME / A-record fallback into two pieces with the A record as a callout, since CNAME is the recommended path.
- Dropped the redundant "Redirects temporarily to …" row from the rules table (same as the default 302).
- Mentioned that destinations can be `mailto:`, `ftp:`, `magnet:`, or a relative path (supported by `parse.go` but undocumented).
- Replaced inline `<p style="…">` with a `.note` class.
- Tightened the "How it works" intro and example captions.

**New section**
- "Verifying your setup" with `dig` commands and a hint about the most common parse failure (forgetting the capital `Redirects`).

## Test plan

- [ ] Open the deployed Pages site after merge and click through each section
- [ ] Confirm code samples render correctly (CNAME, A, TXT lines)
- [ ] Confirm the `.note` class renders with the same dim-gray styling as before
- [ ] Spot-check that the error alert (hash-based) still appears when redirected here with `#reason=…`