### PR TITLE
Wrap URL/path tokens to prevent mid-token line breaks

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -204,8 +204,8 @@
         <tbody>
           <tr>
             <td><code>CNAME</code></td>
-            <td><code>go.example.com.</code></td>
-            <td><code>alias.redirect.name.</code></td>
+            <td><code><span class="nb">go.example.com.</span></code></td>
+            <td><code><span class="nb">alias.redirect.name.</span></code></td>
           </tr>
         </tbody>
       </table>
@@ -223,7 +223,7 @@
         <tbody>
           <tr>
             <td><code>TXT</code></td>
-            <td><code>_redirect.go.example.com.</code></td>
+            <td><code><span class="nb">_redirect.go.example.com.</span></code></td>
             <td><code>Redirects to <span class="nb">https://example.com/</span></code></td>
           </tr>
         </tbody>
@@ -291,7 +291,7 @@
     <tbody>
       <tr>
         <td><code>TXT</code></td>
-        <td><code>_redirect.go.example.com.</code></td>
+        <td><code><span class="nb">_redirect.go.example.com.</span></code></td>
         <td><code>Redirects to <span class="nb">https://www.example.com/</span></code></td>
       </tr>
     </tbody>
@@ -303,7 +303,7 @@
     <tbody>
       <tr>
         <td><code>TXT</code></td>
-        <td><code>_redirect.old.example.com.</code></td>
+        <td><code><span class="nb">_redirect.old.example.com.</span></code></td>
         <td><code>Redirects permanently to <span class="nb">https://new.example.com/</span></code></td>
       </tr>
     </tbody>
@@ -315,12 +315,12 @@
     <tbody>
       <tr>
         <td><code>TXT</code></td>
-        <td><code>_redirect.docs.example.com.</code></td>
+        <td><code><span class="nb">_redirect.docs.example.com.</span></code></td>
         <td><code>Redirects from <span class="nb">/api</span> to <span class="nb">https://api-docs.example.com/</span></code></td>
       </tr>
       <tr>
         <td><code>TXT</code></td>
-        <td><code>_redirect.docs.example.com.</code></td>
+        <td><code><span class="nb">_redirect.docs.example.com.</span></code></td>
         <td><code>Redirects to <span class="nb">https://docs.example.com/</span></code></td>
       </tr>
     </tbody>
@@ -332,7 +332,7 @@
     <tbody>
       <tr>
         <td><code>TXT</code></td>
-        <td><code>_redirect.links.example.com.</code></td>
+        <td><code><span class="nb">_redirect.links.example.com.</span></code></td>
         <td><code>Redirects from <span class="nb">/blog/*</span> to <span class="nb">https://blog.example.com/posts/*</span></code></td>
       </tr>
     </tbody>
@@ -344,7 +344,7 @@
     <tbody>
       <tr>
         <td><code>TXT</code></td>
-        <td><code>_redirect.hi.example.com.</code></td>
+        <td><code><span class="nb">_redirect.hi.example.com.</span></code></td>
         <td><code>Redirects to <span class="nb">mailto:hello@example.com</span></code></td>
       </tr>
     </tbody>

--- a/docs/index.html
+++ b/docs/index.html
@@ -173,6 +173,10 @@
       font-size: 0.875rem;
       color: var(--muted);
     }
+
+    .nb {
+      white-space: nowrap;
+    }
   </style>
 </head>
 <body>
@@ -220,7 +224,7 @@
           <tr>
             <td><code>TXT</code></td>
             <td><code>_redirect.go.example.com.</code></td>
-            <td><code>Redirects to https://example.com/</code></td>
+            <td><code>Redirects to <span class="nb">https://example.com/</span></code></td>
           </tr>
         </tbody>
       </table>
@@ -260,7 +264,7 @@
         <td>Same, with explicit status: <code>301</code>, <code>302</code>, <code>307</code>, or <code>308</code></td>
       </tr>
       <tr>
-        <td><code>Redirects from /path/* to https://example.com/*</code></td>
+        <td><code>Redirects from <span class="nb">/path/*</span> to <span class="nb">https://example.com/*</span></code></td>
         <td>Wildcard: whatever <code>*</code> matches in the path replaces <code>*</code> in the destination</td>
       </tr>
     </tbody>
@@ -288,7 +292,7 @@
       <tr>
         <td><code>TXT</code></td>
         <td><code>_redirect.go.example.com.</code></td>
-        <td><code>Redirects to https://www.example.com/</code></td>
+        <td><code>Redirects to <span class="nb">https://www.example.com/</span></code></td>
       </tr>
     </tbody>
   </table>
@@ -300,7 +304,7 @@
       <tr>
         <td><code>TXT</code></td>
         <td><code>_redirect.old.example.com.</code></td>
-        <td><code>Redirects permanently to https://new.example.com/</code></td>
+        <td><code>Redirects permanently to <span class="nb">https://new.example.com/</span></code></td>
       </tr>
     </tbody>
   </table>
@@ -312,12 +316,12 @@
       <tr>
         <td><code>TXT</code></td>
         <td><code>_redirect.docs.example.com.</code></td>
-        <td><code>Redirects from /api to https://api-docs.example.com/</code></td>
+        <td><code>Redirects from <span class="nb">/api</span> to <span class="nb">https://api-docs.example.com/</span></code></td>
       </tr>
       <tr>
         <td><code>TXT</code></td>
         <td><code>_redirect.docs.example.com.</code></td>
-        <td><code>Redirects to https://docs.example.com/</code></td>
+        <td><code>Redirects to <span class="nb">https://docs.example.com/</span></code></td>
       </tr>
     </tbody>
   </table>
@@ -329,7 +333,7 @@
       <tr>
         <td><code>TXT</code></td>
         <td><code>_redirect.links.example.com.</code></td>
-        <td><code>Redirects from /blog/* to https://blog.example.com/posts/*</code></td>
+        <td><code>Redirects from <span class="nb">/blog/*</span> to <span class="nb">https://blog.example.com/posts/*</span></code></td>
       </tr>
     </tbody>
   </table>
@@ -341,7 +345,7 @@
       <tr>
         <td><code>TXT</code></td>
         <td><code>_redirect.hi.example.com.</code></td>
-        <td><code>Redirects to mailto:hello@example.com</code></td>
+        <td><code>Redirects to <span class="nb">mailto:hello@example.com</span></code></td>
       </tr>
     </tbody>
   </table>


### PR DESCRIPTION
## Summary

Fixes a regression in the design pass where the Path-routing example was breaking `https://api-docs.example.com/` at the hyphen between "api-" and "docs". Hyphens are default line-break opportunities per UAX #14, and there's no CSS that suppresses hyphen breaks while still allowing space breaks.

The fix is to wrap each URL, path, and `mailto:` token in `<span class="nb">` (with `white-space: nowrap`). Spaces between tokens remain normal break opportunities, so longer values still wrap cleanly between words rather than mid-token.

Affected rows: the Setup step 2 TXT example, the wildcard row in the Redirect rules table, and all five Examples.

## Test plan

- [ ] Open the deployed Pages site and shrink the viewport / use mobile width
- [ ] Confirm Path routing's `https://api-docs.example.com/` stays on one line (or breaks before the URL, not at the hyphen)
- [ ] Confirm Wildcard forwarding's `https://blog.example.com/posts/*` doesn't break at the slash or hyphen
- [ ] Confirm the multi-token values still wrap at word boundaries (e.g. "Redirects to" on line 1, URL on line 2) when too long